### PR TITLE
チャートに注釈追加

### DIFF
--- a/app/ui/dashboard/revenue-chart.tsx
+++ b/app/ui/dashboard/revenue-chart.tsx
@@ -51,6 +51,9 @@ export default async function RevenueChart() {
             </div>
           ))}
         </div>
+        <span className='mt-5 text-gray-500 text-sm block'>
+          横軸は月、縦軸は売上額を表し、棒の高さで月ごとの売上を比較できます。
+        </span>
         <div className="flex items-center pb-2 pt-6">
           <CalendarIcon className="h-5 w-5 text-gray-500" />
           <h3 className="ml-2 text-sm text-gray-500 ">Last 12 months</h3>


### PR DESCRIPTION
## 対応issue

Closes #12

## 対応内容

- 売上チャートに、チャートの見方の注釈を追加

## 工夫したところ

- テキストの色を薄く、大きさを小さく表示することで、チャートを邪魔しないように実装。

## スクリーンショット
### Before
<img width="1262" height="498" alt="image" src="https://github.com/user-attachments/assets/49604275-64c5-4901-8d3d-3d405864fb3f" />

### After
<img width="1333" height="559" alt="image" src="https://github.com/user-attachments/assets/a9f7c403-eab1-46c2-a7ad-7364073e8304" />
