### PR TITLE
請求リストにユーザーごとの区切り線を追加

### DIFF
--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -11,7 +11,7 @@ export default async function LatestInvoices() {
         Latest Invoices
       </h2>
       <div className="flex grow flex-col justify-between rounded-xl bg-gray-50 p-4">
-        <div className="px-6">
+        <div className="px-6 divide-y divide-gray-300">
           {latestInvoices.map((invoice, i) => {
             return (
               <div


### PR DESCRIPTION
## 対応issue

Closes https://github.com/takenoya-riku/nextjs-dashboard/issues/15

## 対応内容

- 請求リストに divide-y を適用し、ユーザーごとに行を区切り表示

## 工夫したところ

- 必要な情報の妨げにならないような色で調整

## スクリーンショット
### Before
<img width="1213" height="524" alt="image" src="https://github.com/user-attachments/assets/b100a858-31ba-46d3-89d5-206231d02492" />

### After
<img width="995" height="399" alt="image" src="https://github.com/user-attachments/assets/1e3f85cf-250a-4ee8-8f44-bc61ecb00261" />
