### PR TITLE
A-1：【ダッシュボード】PCレイアウト修正

### DIFF
--- a/app/dashboard/(overview)/page.tsx
+++ b/app/dashboard/(overview)/page.tsx
@@ -11,12 +11,12 @@ export default async function Page() {
             <h1 className={`${lusitana.className} mb-4 text-xl`}>
                 Dashboard
             </h1>
-            <div>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 <Suspense fallback={<CardSkeleton />}>
                     <CardWrapper />
                 </Suspense>
             </div>
-            <div>
+            <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-4 lg:grid-cols-8">
                 <Suspense fallback={<RevenueChartSkeleton />}>
                     <RevenueChart />
                 </Suspense>


### PR DESCRIPTION
## 対応issue

Closes #6 

## 対応内容

- PC画面でのレイアウト調整
  - 統計カードの4つの要素を横並びで表示
  - 売上グラフと請求リストを横並びで表示

## 工夫したところ

- 横並びの方法としてflexという選択肢もあったが、統計カードで各要素が潰れてしまい、解消には別コンポーネントへの修正が必要となるため、gridを使ってシンプルに実装した。
- 統計カードのセクションと売上グラフ/請求リストのセクション間が詰まってしまったため、余白を設けた。
- 統計カードの各要素とセクション間の余白は間隔を均等にし、統一されたデザインで見やすく設定した。

## スクリーンショット
### Before
<img width="1552" height="900" alt="Screenshot 2025-09-24 at 14 21 18" src="https://github.com/user-attachments/assets/6a3ee8c0-fe29-425a-8173-fee4f5c8c2a2" />


### After
<img width="1552" height="900" alt="Screenshot 2025-09-24 at 14 20 43" src="https://github.com/user-attachments/assets/649d9e49-3fbf-4d1a-88af-0dae641cfd50" />
