### PR TITLE
グラフにホバーアクションを追加

### DIFF
--- a/app/ui/dashboard/revenue-chart.tsx
+++ b/app/ui/dashboard/revenue-chart.tsx
@@ -40,11 +40,16 @@ export default async function RevenueChart() {
           {revenue.map((month) => (
             <div key={month.month} className="flex flex-col items-center gap-2">
               <div
-                className="w-full rounded-md bg-blue-300"
+                className="w-full rounded-md bg-blue-300 hover:bg-blue-600 group relative"
                 style={{
                   height: `${(chartHeight / topLabel) * month.revenue}px`,
                 }}
-              ></div>
+              >
+                <span
+                  className='opacity-0 group-hover:opacity-100 absolute -top-6 left-1/2 -translate-x-1/2'>
+                  {month.revenue}
+                </span>
+              </div>
               <p className="text-sm text-gray-400">
                 {month.month}
               </p>


### PR DESCRIPTION
## 対応issue

Closes #13 

## 対応内容

- 売り上げグラフにホバーアクション追加
　- ホバー時に棒を濃い青に色変え
　- ホバー時に単月の売り上げがテキスト表示

## 工夫したところ

- 文字がグラフに重ならないように、グラフの上に表示した

## スクリーンショット
### Before
<img width="755" height="436" alt="image" src="https://github.com/user-attachments/assets/e4f59ea5-a771-4cdc-a44a-41216039a3d3" />

### After
<img width="754" height="494" alt="image" src="https://github.com/user-attachments/assets/37b06305-3346-453c-811a-f41dd9fead3f" />
