### PR TITLE
【売り上げグラフ】スマホ画面で売り上げグラフの月名を斜めに

### DIFF
--- a/app/ui/dashboard/revenue-chart.tsx
+++ b/app/ui/dashboard/revenue-chart.tsx
@@ -45,7 +45,7 @@ export default async function RevenueChart() {
                   height: `${(chartHeight / topLabel) * month.revenue}px`,
                 }}
               ></div>
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-gray-400 -rotate-45 lg:rotate-0">
                 {month.month}
               </p>
             </div>


### PR DESCRIPTION
## 対応issue

Closes #14 

## 対応内容

- スマホ画面にした時、グラフの月名ラベルを45度に斜めとする実装

## 工夫したところ

- 45度の斜めにすることで、文字が読めてかつ隣とも余白を設けられる

## スクリーンショット
### Before
<img width="446" height="388" alt="image" src="https://github.com/user-attachments/assets/7e895c22-79f9-4f73-be03-58766f8cfee1" />

### After
<img width="453" height="402" alt="image" src="https://github.com/user-attachments/assets/95ac0c68-831b-4c64-801c-75f2e4072434" />
