### PR TITLE
【サイドメニュー】アイコン追加

### DIFF
--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -35,6 +35,7 @@ export default function NavLinks() {
               'flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm front-medium md:flex-none md:justify-start md:p-2 md:px-3'
             )}
           >
+            <LinkIcon className='w-5 h-5' />
             <p className="hidden md:block">{link.name}</p>
           </Link>
         );


### PR DESCRIPTION
## 対応issue

Closes #18

## 対応内容

- サイドメニューのリンクにアイコンを追加

## 工夫したところ

- 大きさを小さく固定し、テキストを邪魔しないように設置

## スクリーンショット
### Before
<img width="265" height="266" alt="image" src="https://github.com/user-attachments/assets/daa1eca1-5a5c-4298-b14c-b58e483cef4e" />

### After
<img width="271" height="282" alt="image" src="https://github.com/user-attachments/assets/24ff8b42-33ed-4e3c-9481-339f2f84d7c7" />
