### PR TITLE
D-2：【請求リスト】情報量の段階化

### DIFF
--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -11,7 +11,7 @@ export default async function LatestInvoices() {
         Latest Invoices
       </h2>
       <div className="flex grow flex-col justify-between rounded-xl bg-gray-50 p-4">
-        <div className="px-6">
+        <div className="px-6 divide-y divide-gray-300">
           {latestInvoices.map((invoice, i) => {
             return (
               <div
@@ -32,7 +32,7 @@ export default async function LatestInvoices() {
                     <p className="truncate text-sm font-semibold md:text-base">
                       {invoice.name}
                     </p>
-                    <p className="text-sm text-gray-500">
+                    <p className="hidden md:block text-sm text-gray-500">
                       {invoice.email}
                     </p>
                   </div>


### PR DESCRIPTION
## 対応issue

Closes https://github.com/takenoya-riku/nextjs-dashboard/issues/16

## 対応内容

- スマホ画面（〜767px）：メールアドレスは hidden で非表示
- PC画面（768px〜）：block で表示

## 工夫したところ

- 複雑な条件分岐をせず、Tailwind CSS のユーティリティの `hidden md:block` のシンプルな記述で実現
- 保守性が高く、誰が見ても「画面サイズで表示・非表示を切り替えている」ことが直感的に分かる

## スクリーンショット
### Before
<img width="568" height="555" alt="image" src="https://github.com/user-attachments/assets/3e424c83-4dbb-4067-b754-5708b296bfa5" />

### After
<img width="560" height="582" alt="image" src="https://github.com/user-attachments/assets/937023cf-8038-41fb-8f66-3a1db4b9aed6" />
