### PR TITLE
D-3：【請求リスト】カーソルを重ねた時のデザイン強調

### DIFF
--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -17,7 +17,8 @@ export default async function LatestInvoices() {
               <div
                 key={invoice.id}
                 className={clsx(
-                  'flex flex-row items-center justify-between py-4'
+                  'flex flex-row items-center justify-between py-4 px-2 rounded-lg transition-colors',
+                  'hover:bg-blue-50'
                 )}
               >
                 <div className="flex items-center">


### PR DESCRIPTION
## 対応issue

Closes https://github.com/takenoya-riku/nextjs-dashboard/issues/17

## 対応内容

- 行にホバーしたときに背景色を変更
Tailwind CSS の `hover:bg-blue-50` を付与し、対象行を淡い水色にすることで、ホバー中であることが直感的に分かるようにした

- スムーズなアニメーションを追加
`transition-colors` をクラスに加えて、背景色の切り替えを自然にし、UI の違和感を減らした

## 工夫したところ

- 強調しすぎない色を選定
`blue-100` だとやや濃く、視線が奪われてしまうため、あえて薄い `blue-50` を採用

## スクリーンショット
### Before
<img width="1630" height="391" alt="image" src="https://github.com/user-attachments/assets/f159e03c-4c97-4680-b4b5-19d6b84912bf" />

### After
<img width="1626" height="424" alt="image" src="https://github.com/user-attachments/assets/90e403eb-2014-4b66-88b6-7bbc810c5fba" />
