### PR TITLE
【サイドナビ】ページの現在位置がわかるようにデザイン追加

### DIFF
--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -32,7 +32,10 @@ export default function NavLinks() {
             key={link.name}
             href={link.href}
             className={clsx(
-              'flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm front-medium md:flex-none md:justify-start md:p-2 md:px-3'
+              'flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm front-medium md:flex-none md:justify-start md:p-2 md:px-3',
+              {
+                'bg-sky-100 text-blue-600': pathname === link.href
+              }
             )}
           >
             <p className="hidden md:block">{link.name}</p>


### PR DESCRIPTION
## 対応issue

Closes #19 

## 対応内容

- サイドナビで現在のページがわかるように、項目の文字を青く・背景を水色に変更

## 工夫したところ

- 文字と背景で違いがわかるように実装

## スクリーンショット
### Before
<img width="252" height="282" alt="image" src="https://github.com/user-attachments/assets/1850e244-6d3e-4a51-a145-0a617ddfb77e" />

### After
<img width="285" height="311" alt="image" src="https://github.com/user-attachments/assets/f645183d-371a-49bd-b453-9540835b96a9" />
