### PR TITLE
【主要指標】タイトルにアイコン追加

### DIFF
--- a/app/ui/dashboard/cards.tsx
+++ b/app/ui/dashboard/cards.tsx
@@ -49,6 +49,7 @@ export function Card({
   return (
     <div className="rounded-xl bg-gray-50 p-2 shadow-sm">
       <div className="flex p-4">
+        <Icon className='w-5'/>
         <h3 className="ml-2 text-sm font-medium">{title}</h3>
       </div>
       <p


### PR DESCRIPTION
## 対応issue

Closes #9 

## 対応内容

- 主要指標カードのタイトル隣にアイコンを設置

## 工夫したところ

- アイコンのサイズを調整し、タイトルより目立たないようにした

## スクリーンショット
### Before

### After
